### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block listing `master` and `1.x` to the Gradle workflow on the `1.x` maintenance branch.
- Mirrors the app-booster maintenance-branch pattern so `1.x` artifacts can be released alongside `master`.

This branch was cut from `master` HEAD (`a5f5940`) at `xpVersion=7.5.0` / `version=1.0.2-SNAPSHOT` to preserve the XP 7 maintenance state. No `gradle.properties`, `enonic-docgen.yml`, or `docs/versions.json` changes belong here — those are master-only per the reference pattern.

## Test plan

- [ ] CI green on `chore/1.x-add-release-branch` against `1.x`.