### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,12 @@ repositories {
 dependencies {
     compileOnly xplibs.api.script
 
-    implementation 'org.commonmark:commonmark:0.28.0'
+    implementation libs.commonmark
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation platform( 'org.junit:junit-bom:6.0.3' )
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation platform( libs.junit.bom )
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
 }
 
 test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+commonmark = "0.28.0"
+junit-bom = "6.0.3"
+
+[libraries]
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }


### PR DESCRIPTION
## Summary

Move inline dependency versions in `build.gradle` to a new `gradle/libs.versions.toml` catalog. Pin-for-pin migration — no version bumps.

This aligns `lib-markdown` with the ~half of the IdeaProjects tree that already uses a TOML catalog (e.g. `app-features`, `lib-explorer`), making future bulk dep bumps easier and keeping version pinning visible in one place.

## Conventions adopted

- Alphabetical sort in both `[versions]` and `[libraries]`.
- Lowercase hyphen-separated keys (matching `app-features`).
- `xpVersion` stays in `gradle.properties` — left untouched.
- `xplibs.*` accessors unchanged.
- No `[plugins]` block — only `com.enonic.defaults` has an inline version and a single-entry block isn't worth the heft.

## Catalog

```toml
[versions]
commonmark = "0.28.0"
junit-bom = "6.0.3"

[libraries]
commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` green locally
- [x] `./gradlew dependencies` output (runtime + testRuntime) byte-identical to pre-migration HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)