### PR TITLE
Add @enonic-types/lib-markdown types package #81

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             1.x

--- a/build.gradle
+++ b/build.gradle
@@ -34,3 +34,15 @@ jacocoTestReport {
 }
 
 check.dependsOn jacocoTestReport
+
+// Assemble the @enonic-types/lib-markdown npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,11 @@
+declare module "/lib/markdown" {
+    /**
+     * Renders markdown to HTML.
+     *
+     * @param input Markdown source to render.
+     * @returns The rendered HTML.
+     */
+    export function render(input: string): string;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-markdown",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Markdown library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-markdown",
+    "markdown",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-markdown#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-markdown.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-markdown/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for lib-markdown so consumers get typed access to `/lib/markdown` instead of going untyped (or hand-maintaining local `.d.ts` copies).

## Changes
- `types/index.d.ts` — ambient module declaration for `/lib/markdown` with the single exported `render(input: string): string`.
- `types/package.json` — `@enonic-types/lib-markdown` manifest with `types: index.d.ts`, `publishConfig.access: public`, `dependencies: { "@enonic-types/core": "^8.0.0" }`, `version: 0.0.0` (substituted at build time).
- `build.gradle` — `assembleTypes` Copy task builds `build/types` with `project.version` injected; `jar.dependsOn assembleTypes` (mirrors lib-mustache's pattern; no node build needed for a pure-JS lib).
- `enonic-gradle.yml` — `npmPublish: true` on `build-and-publish` + top-level `permissions: { id-token: write, contents: write }` for npm OIDC / trusted publishing.

## Verified locally
- `./gradlew build` green.
- `build/types/` contains `index.d.ts` + `package.json` with `version: 2.1.0-SNAPSHOT` substituted from `project.version`.
- `index.d.ts` type-checks against a consumer with `paths: { "/lib/markdown": ["node_modules/@enonic-types/lib-markdown"] }` (the standard XP consumer setup) — `render("...")` types as `string`; `render(123)` correctly errors on `number` not assignable to `string`.

## Typed surface
Enumerated against `src/main/resources/lib/markdown.js` and `MarkdownService.java`. The lib exports a single function:

| Export | Signature | Source of truth |
|--------|-----------|-----------------|
| `render` | `(input: string) => string` | `markdown.js:16-18` → `MarkdownService.render(String)` |

**Note:** the first publish of a brand-new `@enonic-types/lib-markdown` may need npm trusted-publisher / package access configured org-side. Depends on `enonic/release-tools#71` (publish-only `npmPublish`) — merged.

Closes #81

Reference implementation: enonic/lib-mustache#66.